### PR TITLE
Always wait until DCL to refresh controllers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,9 +150,15 @@ export function refresh() {
 
 }
 
-if (['interactive', 'complete'].includes(document.readyState)) {
+if (document.readyState === 'complete') {
+  // All sub-resources have finished loading — safe to invoke refresh
   refresh();
 } else {
+  // If 'loading' or 'interactive', not all sub-resources have finished loading.
+  // Specifically, deferred scripts begin executing in the 'interactive' state.
+  // This means that if a deferred site-bundle.js tries to refresh controllers
+  // immediately rather than waiting for DCL, it will break the event listener
+  // dependency order on V6 rollups.
   document.addEventListener('DOMContentLoaded', refresh);
 }
 


### PR DESCRIPTION
This change ensures that deferred scripts are compatible with squarespace-controller. If a template script (e.g. site-bundle) is deferred, the controllers might preemptively refresh since `readyState` will be `interactive`. 

When scripts are synchronous, the readyState will still be `loading` which means the controllers refresh on DCL. By only refreshing on `complete`, this makes deferred scripts work in essentially the same way as synchronous scripts by waiting until DCL.